### PR TITLE
feat: surface built components on Home screen & clean dead code

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -11,17 +11,19 @@ import {
 	getDailyMessage,
 } from "@/src/components/MotivationCard";
 import { PrivacyBadge } from "@/src/components/PrivacyBadge";
+import { TimeSavedCard } from "@/src/components/TimeSavedCard";
 import { colors } from "@/src/constants/theme";
 import { useAppState } from "@/src/contexts/AppStateContext";
 import { getCatalog } from "@/src/data/seed-loader";
 import { useCheckin } from "@/src/hooks/useCheckin";
 import { useContent } from "@/src/hooks/useContent";
+import { useWeeklySuccessCount } from "@/src/hooks/useWeeklySuccessCount";
 import { getLocalDateString } from "@/src/utils/date";
 import { router } from "expo-router";
 import type React from "react";
 import { useCallback, useState } from "react";
 import { ScrollView, StyleSheet, View } from "react-native";
-import { Button, Card, Chip, Surface, Text } from "react-native-paper";
+import { Button, Card, Chip, Text } from "react-native-paper";
 
 // ---------------------------------------------------------------------------
 // Component
@@ -44,6 +46,7 @@ export default function HomeScreen(): React.ReactElement {
 	} = useContent(userProfile?.created_at ?? null);
 
 	const checkin = useCheckin();
+	const { weeklySuccessCount } = useWeeklySuccessCount();
 	const [checkinOverlayVisible, setCheckinOverlayVisible] = useState(false);
 
 	const catalog = getCatalog();
@@ -109,6 +112,9 @@ export default function HomeScreen(): React.ReactElement {
 					</View>
 				</View>
 
+				{/* Daily motivation message */}
+				<MotivationCard message={dailyMessage} />
+
 				{/* Inline check-in hero */}
 				<InlineCheckin checkin={checkin} onExpand={handleCheckinExpand} />
 
@@ -139,6 +145,9 @@ export default function HomeScreen(): React.ReactElement {
 					meditationCount={meditationCount}
 				/>
 
+				{/* Weekly time saved */}
+				<TimeSavedCard weeklySuccessCount={weeklySuccessCount} />
+
 				{/* Spacer to prevent content from hiding behind sticky CTA */}
 				<View style={styles.bottomSpacer} />
 			</ScrollView>
@@ -163,36 +172,6 @@ export default function HomeScreen(): React.ReactElement {
 				<CheckinOverlay checkin={checkin} onClose={handleCheckinClose} />
 			)}
 		</View>
-	);
-}
-
-// ---------------------------------------------------------------------------
-// StatCard sub-component
-// ---------------------------------------------------------------------------
-
-interface StatCardProps {
-	value: number;
-	label: string;
-	valueColor: string;
-}
-
-function StatCard({
-	value,
-	label,
-	valueColor,
-}: StatCardProps): React.ReactElement {
-	return (
-		<Surface style={styles.statCard} elevation={2}>
-			<Text
-				variant="displaySmall"
-				style={[styles.statValue, { color: valueColor }]}
-			>
-				{value}
-			</Text>
-			<Text variant="labelMedium" style={styles.statLabel}>
-				{label}
-			</Text>
-		</Surface>
 	);
 }
 
@@ -242,30 +221,6 @@ const styles = StyleSheet.create({
 	successChipText: {
 		color: colors.success,
 		fontSize: 12,
-	},
-	statsRow: {
-		flexDirection: "row",
-		gap: 12,
-	},
-	statCard: {
-		flex: 1,
-		backgroundColor: colors.surface,
-		borderRadius: 14,
-		padding: 16,
-		alignItems: "center",
-		borderWidth: 1,
-		borderColor: colors.border,
-	},
-	statValue: {
-		fontWeight: "800",
-		letterSpacing: -1,
-		lineHeight: 52,
-	},
-	statLabel: {
-		color: colors.muted,
-		textTransform: "uppercase",
-		letterSpacing: 0.8,
-		marginTop: 2,
 	},
 	courseCard: {
 		backgroundColor: colors.surface,

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -18,6 +18,9 @@ export const MEDITATION_RANK_PER_LEVEL = 5 as const;
 export const LIFE_TREE_CAP = MEDITATION_RANK_CAP;
 export const LIFE_TREE_MEDITATION_PER_LEVEL = MEDITATION_RANK_PER_LEVEL;
 
+/** Estimated minutes saved per successful meditation (used by TimeSavedCard). */
+export const TIME_SAVED_PER_MEDITATION_MINUTES = 15 as const;
+
 // ---------------------------------------------------------------------------
 // Breathing exercise timings (seconds)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Render `MotivationCard`** on Home screen — was imported and computed (`dailyMessage`) but never placed in JSX. Now shows below the header, above the check-in hero.
- **Add `TIME_SAVED_PER_MEDITATION_MINUTES` config constant** (15 min) — `TimeSavedCard` imported it but it didn't exist, which would crash at runtime.
- **Render `TimeSavedCard`** on Home screen — wired up with `useWeeklySuccessCount` hook. Shows below MeditationRank.
- **Remove dead `StatCard`** component and its unused styles (`statsRow`, `statCard`, `statValue`, `statLabel`) — never instantiated anywhere.
- Removed unused `Surface` import from react-native-paper.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 14 suites, 351 tests pass
- [x] `biome check` on changed files — no errors
- [ ] Visual check: MotivationCard visible with daily rotating message
- [ ] Visual check: TimeSavedCard visible showing weekly time saved
- [ ] Scroll behavior works correctly with added cards
- [ ] iOS and Android layout verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)