### PR TITLE
fix: initialize RevenueCat SDK and enforce subscription expiry

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -77,6 +77,8 @@ This document tracks feature-level requirements, screen specs, and implementatio
 - Spend categories: iap, date, gift, tipping, transport, other
 - **[NEW] Time saved calculation:** each avoided session = 12 minutes saved (internal constant)
 - **[DONE] Subscription gating:** `isPremium` is the single gate. True during active trial or paid subscription. False when trial expires without subscribing or subscription lapses. Non-premium users are redirected to paywall.
+- **[DONE] RevenueCat SDK initialization:** `initPurchases()` called once on app mount before any RC operations. Handles init failure gracefully (no crash).
+- **[DONE] Subscription expiry enforcement:** On foreground, after `getCustomerInfo()`, if RC reports no active entitlement and local `expires_at` is past, mark `is_premium = false`, `status = 'expired'`. Offline fallback: if RC call fails, check local `expires_at` + 3-day grace period before marking expired.
 
 ## Data
 - Seed: `data/seed/catalog.json` (triggers, actions, spend delay cards)
@@ -93,6 +95,8 @@ This document tracks feature-level requirements, screen specs, and implementatio
   - **[DONE] Course unlock notification** (8am daily, days 2–7, if lesson not yet completed)
 - Analytics (no free-text, no spend_amount, no notes)
 - Subscription/paywall (IAP — $4.99/month with 7-day free trial, via RevenueCat)
+  - **[DONE] RevenueCat SDK init** on app launch (platform-gated API key)
+  - **[DONE] Subscription expiry enforcement** with 3-day offline grace period
 - **[NEW] Share service** — generate shareable streak card image via native share sheet
 
 ## Accessibility
@@ -106,4 +110,5 @@ This document tracks feature-level requirements, screen specs, and implementatio
 - 2026-02-28: Streamlined onboarding from 10-12 screens to 4 steps; merged Goal+Triggers+Course into single screen; added back navigation; removed demo check-in/action dump; deferred budget setup and notification preference to post-onboarding
 - 2026-02-28: Wired paywall to RevenueCat (purchase + restore); added subscription sync on app foreground; fixed dailyTaskCompleted to query content_progress; added TimeSaved, MotivationCard, StatCards to Home; added "Why We Charge" + plan state handling to Settings; updated paywall model to $4.99/month + 7-day trial; renamed Resist Rank → Meditation Rank in SPEC; removed unused LifeTree components; fixed redundant ternary in panic screen
 - 2026-02-28: Implemented course unlock notification scheduling (8am, days 2–7); removed stealth notification mode; simplified onboarding notification step to On/Off with support text
+- 2026-02-28: RevenueCat IAP fix: added initPurchases() call on app mount; added subscription expiry enforcement with 3-day offline grace period; kept Android API key as placeholder
 - 2026-02-27: Added UI/UX improvement specs (paywall redesign, onboarding demo reset, panic polish, home/progress enhancements, notifications, share, accessibility)

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -35,6 +35,13 @@ export const BREATHING_HOLD = 2 as const;
 export const BREATHING_EXHALE = 6 as const;
 
 // ---------------------------------------------------------------------------
+// Time Saved
+// ---------------------------------------------------------------------------
+
+/** Estimated minutes saved per successful meditation / avoided session. */
+export const TIME_SAVED_PER_MEDITATION_MINUTES = 12 as const;
+
+// ---------------------------------------------------------------------------
 // RevenueCat IAP
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Initialize RevenueCat SDK on app mount** — `initPurchases()` is now called once before any RC operations (purchase, restore, foreground sync). Handles init failure gracefully (no crash on offline/bad key).
- **Subscription expiry enforcement** — When RC reports no active entitlement for a previously-active subscription, status is set to `expired` (not `none`), preserving subscription history.
- **Offline fallback with 3-day grace period** — If RevenueCat is unreachable on foreground, `enforceSubscriptionExpiry()` checks local `expires_at` and only marks the subscription expired after a 3-day grace window passes.
- **Fix pre-existing typecheck error** — Added missing `TIME_SAVED_PER_MEDITATION_MINUTES` constant to config.ts.

## Files changed

| File | Change |
|------|--------|
| `app/_layout.tsx` | Added `initPurchases()` on mount + offline fallback in foreground sync |
| `src/services/subscription-service.ts` | Added `enforceSubscriptionExpiry()`, updated `syncSubscriptionToDb` to use `expired` status |
| `src/constants/config.ts` | Added `TIME_SAVED_PER_MEDITATION_MINUTES` constant |
| `SPEC.md` | Updated spec with new domain rules and changelog |
| `__tests__/services/subscription-service.test.ts` | Added 8 new tests (7 for expiry enforcement + 1 for expired sync path) |

## Test plan

- [x] All 359 tests pass (`pnpm run test`)
- [x] TypeScript compiles without errors (`pnpm run typecheck`)
- [x] Lint passes on all changed files
- [ ] Sandbox: verify `initPurchases()` runs before first RC call
- [ ] Sandbox: verify purchase + restore flows complete successfully
- [ ] Airplane mode: verify offline grace period enforces expiry after 3 days
- [ ] Verify lapsed subscription shows `expired` status (not `none`)
- [ ] Android key remains `TODO_REPLACE_WITH_ANDROID_KEY` — replace before release

🤖 Generated with [Claude Code](https://claude.com/claude-code)