### PR TITLE
fix: UX & data polish — label, stats, docs

### DIFF
--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -49,7 +49,6 @@ interface WeeklyStats {
 	panicSuccessRate: number;
 	panicSuccessCount: number;
 	panicTotalCount: number;
-	meditationCount: number;
 	spendAvoidedCount: number;
 }
 
@@ -86,18 +85,18 @@ function getLastWeekRange(today: string): { start: string; end: string } {
 interface WeekComparisonCardProps {
 	thisWeekSuccessDays: number;
 	lastWeekSuccessDays: number;
-	thisWeekMeditations: number;
-	lastWeekMeditations: number;
+	thisWeekResets: number;
+	lastWeekResets: number;
 }
 
 function WeekComparisonCard({
 	thisWeekSuccessDays,
 	lastWeekSuccessDays,
-	thisWeekMeditations,
-	lastWeekMeditations,
+	thisWeekResets,
+	lastWeekResets,
 }: WeekComparisonCardProps): React.ReactElement {
 	const daysDelta = thisWeekSuccessDays - lastWeekSuccessDays;
-	const meditationsDelta = thisWeekMeditations - lastWeekMeditations;
+	const resetsDelta = thisWeekResets - lastWeekResets;
 
 	function deltaColor(delta: number): string {
 		if (delta > 0) return colors.success;
@@ -136,21 +135,21 @@ function WeekComparisonCard({
 					<View style={styles.comparisonDivider} />
 					<View style={styles.comparisonCol}>
 						<Text variant="labelSmall" style={styles.comparisonColHeader}>
-							Meditations
+							Resets succeeded
 						</Text>
 						<Text variant="titleLarge" style={styles.comparisonThis}>
-							{thisWeekMeditations}
+							{thisWeekResets}
 						</Text>
 						<Text
 							variant="labelSmall"
 							style={[
 								styles.comparisonDelta,
-								{ color: deltaColor(meditationsDelta) },
+								{ color: deltaColor(resetsDelta) },
 							]}
 						>
-							{meditationsDelta === 0
+							{resetsDelta === 0
 								? "— same"
-								: `${deltaStr(meditationsDelta)} vs last week`}
+								: `${deltaStr(resetsDelta)} vs last week`}
 						</Text>
 					</View>
 				</View>
@@ -202,7 +201,6 @@ export default function ProgressScreen(): React.ReactElement {
 		panicSuccessRate: 0,
 		panicSuccessCount: 0,
 		panicTotalCount: 0,
-		meditationCount: 0,
 		spendAvoidedCount: 0,
 	};
 
@@ -270,7 +268,6 @@ export default function ProgressScreen(): React.ReactElement {
 		const successDays = successDaySet.size;
 		const panicTotal = events.filter((e) => e.outcome !== "ongoing").length;
 		const panicSuccess = events.filter((e) => e.outcome === "success").length;
-		const meditationCount = events.filter((e) => e.outcome === "success").length;
 		const spendAvoided = events.filter(
 			(e) => e.urge_kind === "spend" && e.outcome === "success",
 		).length;
@@ -282,7 +279,6 @@ export default function ProgressScreen(): React.ReactElement {
 			panicSuccessRate: panicTotal > 0 ? panicSuccess / panicTotal : 0,
 			panicSuccessCount: panicSuccess,
 			panicTotalCount: panicTotal,
-			meditationCount,
 			spendAvoidedCount: spendAvoided,
 		});
 
@@ -302,9 +298,6 @@ export default function ProgressScreen(): React.ReactElement {
 		}
 
 		const lastWeekSuccessDays = lastWeekSuccessDaySet.size;
-		const lastWeekMeditationCount = lastWeekEvents.filter(
-			(e) => e.outcome === "success",
-		).length;
 		const lastWeekPanicTotal = lastWeekEvents.filter(
 			(e) => e.outcome !== "ongoing",
 		).length;
@@ -323,7 +316,6 @@ export default function ProgressScreen(): React.ReactElement {
 				lastWeekPanicTotal > 0 ? lastWeekPanicSuccess / lastWeekPanicTotal : 0,
 			panicSuccessCount: lastWeekPanicSuccess,
 			panicTotalCount: lastWeekPanicTotal,
-			meditationCount: lastWeekMeditationCount,
 			spendAvoidedCount: lastWeekSpendAvoided,
 		});
 	}, [db, today]);
@@ -641,16 +633,16 @@ export default function ProgressScreen(): React.ReactElement {
 					<WeekComparisonCard
 						thisWeekSuccessDays={weeklyStats.successDays}
 						lastWeekSuccessDays={lastWeekStats.successDays}
-						thisWeekMeditations={weeklyStats.meditationCount}
-						lastWeekMeditations={lastWeekStats.meditationCount}
+						thisWeekResets={weeklyStats.panicSuccessCount}
+						lastWeekResets={lastWeekStats.panicSuccessCount}
 					/>
 
 					{/* Weekly insight cards */}
 					<WeeklyInsightCard
 						dowCounts={dowCounts}
 						timeCounts={timeCounts}
-						thisWeekMeditations={weeklyStats.meditationCount}
-						lastWeekMeditations={lastWeekStats.meditationCount}
+						thisWeekResets={weeklyStats.panicSuccessCount}
+						lastWeekResets={lastWeekStats.panicSuccessCount}
 					/>
 
 					{/* Weekly stats */}
@@ -685,14 +677,6 @@ export default function ProgressScreen(): React.ReactElement {
 									weeklyStats.panicSuccessCount > 0
 										? colors.primary
 										: colors.muted
-								}
-							/>
-							<Divider style={styles.divider} />
-							<StatRow
-								label="Meditations this week"
-								value={String(weeklyStats.meditationCount)}
-								valueColor={
-									weeklyStats.meditationCount > 0 ? colors.secondary : colors.muted
 								}
 							/>
 							<Divider style={styles.divider} />

--- a/src/components/InlineCheckin.tsx
+++ b/src/components/InlineCheckin.tsx
@@ -88,7 +88,7 @@ export function InlineCheckin({
 					style={styles.detailsLink}
 					onPress={handleDetails}
 				>
-					Edit details
+					View details
 				</Text>
 			</Surface>
 		);

--- a/src/components/WeeklyInsightCard.tsx
+++ b/src/components/WeeklyInsightCard.tsx
@@ -39,8 +39,8 @@ const TIME_LABELS: Record<string, string> = {
 function buildInsights(
 	dowCounts: DayOfWeekCount[],
 	timeCounts: TimeOfDayCount[],
-	thisWeekMeditations: number,
-	lastWeekMeditations: number,
+	thisWeekResets: number,
+	lastWeekResets: number,
 ): string[] {
 	const insights: string[] = [];
 
@@ -51,7 +51,7 @@ function buildInsights(
 	);
 	if (bestDow.count > 0) {
 		insights.push(
-			`You meditate most on ${DOW_LABELS[bestDow.dayOfWeek] ?? "weekdays"}`,
+			`You reset most on ${DOW_LABELS[bestDow.dayOfWeek] ?? "weekdays"}`,
 		);
 	}
 
@@ -67,20 +67,20 @@ function buildInsights(
 	}
 
 	// Weekly trend
-	if (lastWeekMeditations > 0) {
+	if (lastWeekResets > 0) {
 		const pct = Math.round(
-			((thisWeekMeditations - lastWeekMeditations) / lastWeekMeditations) * 100,
+			((thisWeekResets - lastWeekResets) / lastWeekResets) * 100,
 		);
 		if (pct > 0) {
-			insights.push(`Meditations up ${pct}% vs last week`);
+			insights.push(`Resets up ${pct}% vs last week`);
 		} else if (pct < 0) {
-			insights.push(`Meditations down ${Math.abs(pct)}% vs last week`);
+			insights.push(`Resets down ${Math.abs(pct)}% vs last week`);
 		} else {
-			insights.push("Same number of meditations as last week");
+			insights.push("Same number of resets as last week");
 		}
-	} else if (thisWeekMeditations > 0) {
+	} else if (thisWeekResets > 0) {
 		insights.push(
-			`${thisWeekMeditations} meditation${thisWeekMeditations > 1 ? "s" : ""} this week — great start`,
+			`${thisWeekResets} reset${thisWeekResets > 1 ? "s" : ""} this week — great start`,
 		);
 	}
 
@@ -94,8 +94,8 @@ function buildInsights(
 interface WeeklyInsightCardProps {
 	dowCounts: DayOfWeekCount[];
 	timeCounts: TimeOfDayCount[];
-	thisWeekMeditations: number;
-	lastWeekMeditations: number;
+	thisWeekResets: number;
+	lastWeekResets: number;
 	rotateIntervalMs?: number;
 }
 
@@ -106,15 +106,15 @@ interface WeeklyInsightCardProps {
 export function WeeklyInsightCard({
 	dowCounts,
 	timeCounts,
-	thisWeekMeditations,
-	lastWeekMeditations,
+	thisWeekResets,
+	lastWeekResets,
 	rotateIntervalMs = 4000,
 }: WeeklyInsightCardProps): React.ReactElement | null {
 	const insights = buildInsights(
 		dowCounts,
 		timeCounts,
-		thisWeekMeditations,
-		lastWeekMeditations,
+		thisWeekResets,
+		lastWeekResets,
 	);
 	const [index, setIndex] = useState(0);
 	const opacity = useSharedValue(1);

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -14,6 +14,9 @@ export const MEDITATION_RANK_CAP = 30 as const;
 /** Number of successful meditations required to advance one rank. */
 export const MEDITATION_RANK_PER_LEVEL = 5 as const;
 
+/** Estimated minutes saved per successful meditation/reset. */
+export const TIME_SAVED_PER_MEDITATION_MINUTES = 2 as const;
+
 // Life Tree uses the same progression constants as Meditation Rank.
 export const LIFE_TREE_CAP = MEDITATION_RANK_CAP;
 export const LIFE_TREE_MEDITATION_PER_LEVEL = MEDITATION_RANK_PER_LEVEL;

--- a/src/data/database.ts
+++ b/src/data/database.ts
@@ -14,9 +14,9 @@ CREATE TABLE IF NOT EXISTS user_profile (
   notification_style TEXT NOT NULL DEFAULT 'normal',
   plan_selected TEXT,
   goal_type TEXT,
-  spending_budget_weekly INTEGER,
-  spending_budget_daily INTEGER,
-  spending_limit_mode TEXT
+  spending_budget_weekly INTEGER,  -- V2: budget setup UI not yet implemented
+  spending_budget_daily INTEGER,   -- V2: budget setup UI not yet implemented
+  spending_limit_mode TEXT         -- V2: budget setup UI not yet implemented
 );
 `.trim();
 

--- a/src/data/repositories/progress-repository.ts
+++ b/src/data/repositories/progress-repository.ts
@@ -19,6 +19,11 @@ interface ProgressRow {
 	spend_avoided_count_total: number;
 }
 
+// Maps DB row to domain model.
+// Note: the DB column is `resist_count_total` (legacy name) while the domain
+// model uses `meditation_count_total`. They represent the same value — the
+// cumulative count of successful panic resets. A column rename migration was
+// deferred to avoid risk; the mapping is handled here instead.
 function rowToProgress(row: ProgressRow): Progress {
 	return {
 		date_local: row.date_local,

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -50,9 +50,9 @@ export interface UserProfile {
   notification_style: NotificationStyle;
   plan_selected: string;
   goal_type: GoalType;
-  spending_budget_weekly: number | null;
-  spending_budget_daily: number | null;
-  spending_limit_mode: SpendingLimitMode | null;
+  spending_budget_weekly: number | null; // V2 — not yet populated; budget setup UI planned for a future release
+  spending_budget_daily: number | null; // V2 — not yet populated
+  spending_limit_mode: SpendingLimitMode | null; // V2 — not yet populated
 }
 
 /**


### PR DESCRIPTION
## Summary

- **"View details" label**: Changed "Edit details" → "View details" on completed check-in card since it navigates to a read-only view
- **Remove duplicate stat**: Removed `meditationCount` from progress weekly stats — it was identical to `panicSuccessCount` (same `outcome === "success"` filter). Renamed UI labels from "Meditations" to "Resets succeeded" for clarity
- **Budget fields documented as V2**: Added comments to `spending_budget_weekly`, `spending_budget_daily`, `spending_limit_mode` in both schema and types marking them as V2 (not yet populated)
- **Column naming documented**: Added code comment in `progress-repository.ts` explaining the `resist_count_total` → `meditation_count_total` mapping
- **Missing constant fix**: Added `TIME_SAVED_PER_MEDITATION_MINUTES` to `config.ts` (was imported but not exported, causing a pre-existing TS error)

## Files changed

| File | Change |
|------|--------|
| `src/components/InlineCheckin.tsx` | "Edit details" → "View details" |
| `app/(tabs)/progress.tsx` | Remove duplicate `meditationCount` from `WeeklyStats`, update comparison card props |
| `src/components/WeeklyInsightCard.tsx` | Rename props/labels from "meditations" to "resets" |
| `src/constants/config.ts` | Add missing `TIME_SAVED_PER_MEDITATION_MINUTES` constant |
| `src/data/database.ts` | V2 comments on budget columns |
| `src/domain/types.ts` | V2 comments on budget fields |
| `src/data/repositories/progress-repository.ts` | Document column naming mismatch |

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes (351/351)
- [x] Completed check-in shows "View details" (not "Edit details")
- [x] Progress screen stats are clearly labeled and not misleading
- [x] Budget fields documented as V2
- [x] Column naming mismatch documented with code comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)